### PR TITLE
Allow verifying access tokens

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+src/
 test/
 demo/
 build/test/

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src/
 test/
 demo/
 build/test/

--- a/package.json
+++ b/package.json
@@ -8,13 +8,12 @@
     "test": "node build/test/test-agent.js",
     "check": "gts check",
     "clean": "gts clean",
-    "compile": "npx -p typescript@^2.6.1 -p @types/debug@^0.0.30 -p @types/jsonwebtoken@^7.2.3 -p @types/request@^2.0.8 tsc -p .",
+    "compile": "tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check",
-    "prepublish": "npm run prepare",
-    "preinstall": "npm run prepare"
+    "prepublish": "npm run prepare"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "test": "node build/test/test-agent.js",
     "check": "gts check",
     "clean": "gts clean",
-    "compile": "tsc -p .",
+    "compile": "npx -p typescript@^2.6.1 tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check",
-    "prepublish": "npm run prepare"
+    "prepublish": "npm run prepare",
+    "prepack": "npm run prepare"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "node build/test/test-agent.js",
     "check": "gts check",
     "clean": "gts clean",
-    "compile": "npx -p typescript@^2.6.1 tsc -p .",
+    "compile": "npx -p typescript@^2.6.1 -p @types/debug@^0.0.30 -p @types/jsonwebtoken@^7.2.3 -p @types/request@^2.0.8 tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pretest": "npm run compile",
     "posttest": "npm run check",
     "prepublish": "npm run prepare",
-    "preinstall": "npm run prepapre"
+    "preinstall": "npm run prepare"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "node build/test/test-agent.js",
     "check": "gts check",
     "clean": "gts clean",
-    "compile": "npx tsc -p .",
+    "compile": "npx -p typescript@^2.6.1 tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "node build/test/test-agent.js",
     "check": "gts check",
     "clean": "gts clean",
-    "compile": "tsc -p .",
+    "compile": "npx tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,12 @@
     "test": "node build/test/test-agent.js",
     "check": "gts check",
     "clean": "gts clean",
-    "compile": "npx -p typescript@^2.6.1 tsc -p .",
+    "compile": "tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check",
-    "prepublish": "npm run prepare",
-    "prepack": "npm run prepare"
+    "prepublish": "npm run prepare"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prepare": "npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check",
-    "prepublish": "npm run prepare"
+    "prepublish": "npm run prepare",
+    "preinstall": "npm run prepapre"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export class Validator {
    *
    */
   constructor(
-      private iss: string, private aud: string, private token_use: string, private fakeAuth = false) {}
+      private iss: string, private aud: string, private token_use: string = 'id', private fakeAuth = false) {}
 
   /**
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export class Validator {
    *
    */
   constructor(
-      private iss: string, private aud: string, private token_use, private fakeAuth = false) {}
+      private iss: string, private aud: string, private token_use: string, private fakeAuth = false) {}
 
   /**
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export class Validator {
    *
    */
   constructor(
-      private iss: string, private aud: string, private fakeAuth = false) {}
+      private iss: string, private aud: string, private token_use, private fakeAuth = false) {}
 
   /**
    *
@@ -41,7 +41,7 @@ export class Validator {
         debug('PEMs generated from JWKs.');
       }
       tokenPayload =
-          await validateIdToken(token, this.pems, this.iss, this.aud);
+          await validateIdToken(token, this.pems, this.iss, this.aud, this.token_use);
     }
 
     debug('JWT token validated.');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import {JWK, JWT, PemDictionary, PolicyDocument, PolicyStatement} from './models
 
 
 export const validateIdToken =
-    async (jwtToken: string, pems: PemDictionary, iss: string, aud: string) => {
+    async (jwtToken: string, pems: PemDictionary, iss: string, aud: string, token_use: string) => {
   const decodedJwt = jwt.decode(jwtToken, {complete: true}) as JWT;
   // Fail if the token is not jwt
   if (!decodedJwt) {
@@ -19,7 +19,7 @@ export const validateIdToken =
   }
 
   // Reject the jwt if it's not an id token
-  if (!(decodedJwt.payload.token_use === 'id')) {
+  if (!(decodedJwt.payload.token_use === token_use)) {
     throw new Error('Invalid token_use: ' + decodedJwt.payload.token_use);
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,8 +23,8 @@ export const validateIdToken =
     throw new Error('Invalid token_use: ' + decodedJwt.payload.token_use);
   }
 
-  // Fail if token audience is invalid
-  if (decodedJwt.payload.aud !== aud) {
+  // Fail if token audience is invalid and using id token
+  if (decodedJwt.payload.aud !== aud && token_use === 'id') {
     throw new Error('Invalid aud: ' + decodedJwt.payload.aud);
   }
 

--- a/test/test-agent.ts
+++ b/test/test-agent.ts
@@ -11,7 +11,7 @@ async function testToken(iss: string, aud: string, rl: readline.ReadLine) {
            });
          })
       .then((token) => {
-        const validator = new Validator(iss, aud);
+        const validator = new Validator(iss, aud, 'id');
         return validator.validate(token);
       });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "allowUnusedLabels": false,
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2015"],
+    "lib": ["es2015","esnext"],
     "noFallthroughCasesInSwitch": true,
     "noEmitOnError": true,
     "noImplicitReturns": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "allowUnusedLabels": false,
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2015","esnext"],
+    "lib": ["es2015"],
     "noFallthroughCasesInSwitch": true,
     "noEmitOnError": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
Previously the verification was hard coded to support only id as token_use. I opened it up to allow an input parameter from the validator's constructor to allow access token or any other potential types as well.

I also had to disable checking for aud if it is not an id since access tokens do not come with an aud

Potentially breaking change if users use fakeAuth explicitly.